### PR TITLE
feat: Add Ruff linting and formatting to CI workflow

### DIFF
--- a/.github/workflows/dev-workflow.yaml
+++ b/.github/workflows/dev-workflow.yaml
@@ -11,7 +11,28 @@ on:
       - dev
 
 jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: uv pip install .[dev]
+
+      - name: Run ruff linter
+        run: uv run ruff check .
+
+      - name: Run ruff formatter
+        run: uv run ruff format --check .
+
   build:
+    needs: lint-and-format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Integrates Ruff into the `dev-workflow.yaml` GitHub Actions workflow.

A new job `lint-and-format` has been added, which performs the following:
- Checks out the repository.
- Sets up Python 3.11.
- Installs project dependencies, including development dependencies like Ruff, using `uv pip install .[dev]`.
- Runs `uv run ruff check .` to lint the codebase.
- Runs `uv run ruff format --check .` to check code formatting.

The existing `build` job has been updated to depend on the successful completion of the `lint-and-format` job. This ensures that linting and formatting checks pass before the Docker build and test execution.